### PR TITLE
Dedent in display_genre.short_description

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -51,7 +51,7 @@ class Book(models.Model):
         Creates a string for the Genre. This is required to display genre in Admin.
         """
         return ', '.join([ genre.name for genre in self.genre.all()[:3] ])
-        display_genre.short_description = 'Genre'
+    display_genre.short_description = 'Genre'
     
     
     def get_absolute_url(self):


### PR DESCRIPTION
There should be indentation after return statement in display_genre method.
Reference: https://docs.djangoproject.com/en/1.10/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display